### PR TITLE
GitHub Action to Generate Burndown Charts

### DIFF
--- a/.github/workflows/burndown-chart.yml
+++ b/.github/workflows/burndown-chart.yml
@@ -2,9 +2,8 @@ name: Generate Burndown Chart
 
 on:
   workflow_dispatch:
-  # Optional: Run on schedule (uncomment to enable)
-  # schedule:
-  #   - cron: '0 9 * * *'  # Every day at 9 AM UTC
+  schedule:
+    - cron: "0 15 * * *" # 15:00 UTC = 10:00 AM EST / 11:00 AM EDT
 
 jobs:
   generate-burndown:


### PR DESCRIPTION
## Description

This PR introduces a **GitHub Actions workflow to automatically generate sprint burndown charts**, supporting Agile planning and progress tracking throughout the project.

The generated burndown charts are sent directly to the team’s Discord channel, allowing all members to easily monitor sprint progress and remaining work.

---

## Key Changes

- Implemented a **GitHub Action** to generate burndown charts  
- Integrated Discord notifications to automatically share charts in the `#burndown-chart` channel  
- Connected the workflow with GitHub Projects data to reflect real sprint progress  
- Added support for manual triggering via `workflow_dispatch`  

---

## Workflow Behavior

The workflow is designed to generate burndown charts:
- At the **end of each sprint** (primary use case for reporting)  
- Optionally triggered manually when needed  

Discussions were held regarding more frequent triggers (e.g., on issue closure or daily execution), but the team decided that **end-of-sprint generation provides the most relevant and manageable output**.

## Evidence

<img width="628" height="445" alt="image" src="https://github.com/user-attachments/assets/a2fb38b1-d407-4905-88bb-dde3f58968eb" />