### PR TITLE
[#199] FIX BUG: Concordia Shuttle Service not working with directions

### DIFF
--- a/mobile/hooks/useShuttleAvailability.ts
+++ b/mobile/hooks/useShuttleAvailability.ts
@@ -14,6 +14,7 @@
 
 import { useMemo } from 'react';
 import shuttleData from '../data/shuttleSchedule.json';
+import { DEV_OVERRIDE_TIME } from '../utils/devConfig';
 
 export type ShuttleCampus = 'SGW' | 'Loyola';
 
@@ -91,7 +92,7 @@ export function useShuttleAvailability(
   fromCampus: ShuttleCampus
 ): ShuttleAvailability {
   return useMemo(() => {
-    const now = new Date();
+    const now = DEV_OVERRIDE_TIME ?? new Date();
     const nowMinutes = now.getHours() * 60 + now.getMinutes();
 
     const departures = getDepartureTimes(fromCampus, now);

--- a/mobile/utils/devConfig.ts
+++ b/mobile/utils/devConfig.ts
@@ -5,7 +5,7 @@
 // Set to null to use the real clock.
 // Example: new Date('2026-03-09T12:00:00') puts the app at March 9 at noon.
 
-// export const DEV_OVERRIDE_TIME: Date | null = new Date('2026-03-09T18:00:00'); // UNCOMMENT TO USE OVERRIDE TIME
+// export const DEV_OVERRIDE_TIME: Date | null = new Date('2026-03-10T12:00:00'); // UNCOMMENT TO USE OVERRIDE TIME
 export const DEV_OVERRIDE_TIME: Date | null = null; // UNCOMMENT TO USE REAL TIME
 
 


### PR DESCRIPTION
# Summary of changes
Simply added the dev config variable `DEV_OVERRIDE_TIME` in `useShuttleAvailability.ts`. The `now` time variable chooses either the `DEV_OVERRIDE_TIME` (if not null) or gets the current date/time (by creating `new Date()`)

# Visuals
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 20 55 10" src="https://github.com/user-attachments/assets/6125d832-dc78-49d1-ba0c-71a74af6ee98" />

# Steps to test
1. `npx expo run:android` or `npx expo run:ios` depending on elumator device
2. Set the `DEV_OVERRIDE_TIME` to a weekday between 9 AM and 6 PM (make sure the time is after the first / before the last Concordia Shuttle departure time)
3. Select a SGW building (eg. Hall) as start destination & a Loyola building (eg. F.C. Smith) as end destination
4. Select 'Transit' as mode of transport
5. Verify that the 'Use Concordia Shuttle' checkbox is checkable
6. Check the checkbox and click 'Preview Route'