### PR TITLE
AT 2.6 Maestro E2E test for Concordia Shuttle transit flow

### DIFF
--- a/mobile/maestro/shuttle_cross_campus_acceptance.yml
+++ b/mobile/maestro/shuttle_cross_campus_acceptance.yml
@@ -1,0 +1,36 @@
+appId: com.commitandpray.soen390project
+---
+- launchApp
+
+
+- setLocation:
+    latitude: 45.49726
+    longitude: -73.57888
+
+# Cross-campus route setup: Loyola -> SGW
+- tapOn: "Search buildings, rooms"
+- tapOn: "Loyola Campus"
+- tapOn: "Where to?"
+- inputText: "lo"
+- tapOn: Loyola Jesuit Hall and Conference Center (RF)
+
+# Shuttle option should appear for Transit mode.
+- tapOn: "Transit"
+- assertVisible: "Use Concordia Shuttle"
+- tapOn: Use Concordia Shuttle
+- assertVisible: "Next: 12:30"
+- tapOn: Go back
+
+# Open shuttle schedule modal and validate stops + schedule content from JSON.
+- tapOn: "🚌"
+- assertVisible: 🚌 Shuttle Schedule
+- assertVisible: ⚠️ The following departure times are approximate and may vary due to unexpected circumstances, traffic and weather.
+- assertVisible: "Bus Stops"
+- assertVisible: "Loyola Chapel"
+- assertVisible: "Henry F. Hall Building"
+- assertVisible: "Loyola Departures"
+- assertVisible: "SGW Departures"
+- assertVisible: "9:15"
+
+# Show shuttle route on map.
+- tapOn: 🗺️ Show Shuttle Route on Map


### PR DESCRIPTION
This PR introduces a new end-to-end Maestro test that validates the Concordia Shuttle experience within the app. This YAML file contains automated test steps for the shuttle cross-campus acceptance process, including launching the app, setting the location, selecting transit options, and validating shuttle schedule content.

The test currently relies on the fixed value - assertVisible: "Next: 12:30" when validating shuttle departures. Because shuttle timings may vary, this introduces potential flakiness. While acceptable for now, this part of the test will need to be revisited to make it more robust