### PR TITLE
Indoor maps tagged with accessibility data

### DIFF
--- a/mobile/data/buildings/H/1-nav.json
+++ b/mobile/data/buildings/H/1-nav.json
@@ -200,7 +200,7 @@
       "buildingId": "H",
       "floor": 1,
       "x": 367,
-      "y": 567,
+      "y": 565,
       "label": "",
       "accessible": true
     },
@@ -219,8 +219,8 @@
       "type": "doorway",
       "buildingId": "H",
       "floor": 1,
-      "x": 654,
-      "y": 1496,
+      "x": 655,
+      "y": 1495,
       "label": "",
       "accessible": false
     },
@@ -556,7 +556,7 @@
       "buildingId": "H",
       "floor": 1,
       "x": 1644,
-      "y": 979,
+      "y": 980,
       "label": "",
       "accessible": true
     },
@@ -765,14 +765,14 @@
       "target": "H_F1_room_33",
       "type": "hallway",
       "weight": 174,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_room_34",
       "target": "H_F1_room_57",
       "type": "door_to_hallway",
       "weight": 281,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_room_57",
@@ -793,7 +793,7 @@
       "target": "H_F1_room_87",
       "type": "hallway",
       "weight": 84,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_hallway_waypoint_14",
@@ -1101,14 +1101,14 @@
       "target": "H_F1_hallway_waypoint_28",
       "type": "hallway",
       "weight": 415,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_hallway_waypoint_28",
       "target": "H_F1_room_34",
       "type": "hallway",
       "weight": 93,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_hallway_waypoint_28",
@@ -1129,7 +1129,7 @@
       "target": "H_F1_hallway_waypoint_29",
       "type": "hallway",
       "weight": 222,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_hallway_waypoint_29",
@@ -1192,14 +1192,14 @@
       "target": "H_F1_hallway_waypoint_30",
       "type": "door_to_hallway",
       "weight": 69,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_hallway_waypoint_30",
       "target": "H_F1_room_44",
       "type": "hallway",
       "weight": 99,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F1_room_44",

--- a/mobile/data/buildings/H/2-nav.json
+++ b/mobile/data/buildings/H/2-nav.json
@@ -621,14 +621,14 @@
       "target": "H_F2_hallway_waypoint_236",
       "type": "hallway",
       "weight": 135,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_hallway_waypoint_236",
       "target": "H_F2_room_184",
       "type": "hallway",
       "weight": 64,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_hallway_waypoint_250",
@@ -782,14 +782,14 @@
       "target": "H_F2_room_182",
       "type": "hallway",
       "weight": 55,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_room_179",
       "target": "H_F2_room_182",
       "type": "hallway",
       "weight": 130,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_doorway_246",
@@ -859,7 +859,7 @@
       "target": "H_F2_room_182",
       "type": "hallway",
       "weight": 106,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_hallway_waypoint_256",
@@ -957,7 +957,7 @@
       "target": "H_F2_hallway_waypoint_261",
       "type": "hallway",
       "weight": 51,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_hallway_waypoint_261",
@@ -985,7 +985,7 @@
       "target": "H_F2_room_182",
       "type": "hallway",
       "weight": 104,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F2_hallway_waypoint_258",

--- a/mobile/data/buildings/H/8-nav.json
+++ b/mobile/data/buildings/H/8-nav.json
@@ -1019,7 +1019,7 @@
       "type": "stair_landing",
       "buildingId": "H",
       "floor": 8,
-      "x": 1072,
+      "x": 1071,
       "y": 1146,
       "label": "",
       "accessible": true
@@ -1069,7 +1069,7 @@
       "type": "elevator_door",
       "buildingId": "H",
       "floor": 8,
-      "x": 1236,
+      "x": 1235,
       "y": 653,
       "label": "",
       "accessible": true
@@ -1841,14 +1841,14 @@
       "target": "H_F8_doorway_87",
       "type": "door_to_hallway",
       "weight": 64,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_doorway_86",
       "target": "H_F8_doorway_102",
       "type": "door_to_hallway",
       "weight": 73,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_doorway_79",
@@ -1904,14 +1904,14 @@
       "target": "H_F8_doorway_100",
       "type": "door_to_hallway",
       "weight": 64,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_doorway_85",
       "target": "H_F8_doorway_103",
       "type": "door_to_hallway",
       "weight": 56,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_hallway_waypoint_78",
@@ -1988,7 +1988,7 @@
       "target": "H_F8_doorway_104",
       "type": "hallway",
       "weight": 67,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_hallway_waypoint_81",
@@ -2023,7 +2023,7 @@
       "target": "H_F8_doorway_105",
       "type": "door_to_hallway",
       "weight": 83,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F8_hallway_waypoint_105",

--- a/mobile/data/buildings/H/9-nav.json
+++ b/mobile/data/buildings/H/9-nav.json
@@ -359,7 +359,7 @@
       "type": "stair_landing",
       "buildingId": "H",
       "floor": 9,
-      "x": 1427,
+      "x": 1426,
       "y": 631,
       "label": "",
       "accessible": true
@@ -1679,7 +1679,7 @@
       "target": "H_F9_doorway_115",
       "type": "door_to_hallway",
       "weight": 72,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_114",
@@ -1938,14 +1938,14 @@
       "target": "H_F9_doorway_111",
       "type": "door_to_hallway",
       "weight": 58,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_doorway_175",
       "target": "H_F9_doorway_114",
       "type": "door_to_hallway",
       "weight": 69,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_doorway_160",
@@ -2029,7 +2029,7 @@
       "target": "H_F9_doorway_110",
       "type": "door_to_hallway",
       "weight": 70,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_139",
@@ -2190,7 +2190,7 @@
       "target": "H_F9_doorway_112",
       "type": "hallway",
       "weight": 100,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_150",
@@ -2211,7 +2211,7 @@
       "target": "H_F9_doorway_112",
       "type": "hallway",
       "weight": 101,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_122",
@@ -2225,14 +2225,14 @@
       "target": "H_F9_doorway_112",
       "type": "hallway",
       "weight": 144,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_120",
       "target": "H_F9_doorway_113",
       "type": "hallway",
       "weight": 100,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_120",
@@ -2246,7 +2246,7 @@
       "target": "H_F9_hallway_waypoint_119",
       "type": "hallway",
       "weight": 126,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_120",
@@ -2533,7 +2533,7 @@
       "target": "H_F9_hallway_waypoint_165",
       "type": "hallway",
       "weight": 119,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "H_F9_hallway_waypoint_158",

--- a/mobile/data/buildings/MB/S2-nav.json
+++ b/mobile/data/buildings/MB/S2-nav.json
@@ -1379,7 +1379,7 @@
       "target": "MB_F-2_doorway_8",
       "type": "door_to_hallway",
       "weight": 50.8,
-      "accessible": false
+      "accessible": true
     },
     {
       "source": "MB_F-2_hallway_waypoint_4",
@@ -1995,7 +1995,7 @@
       "target": "MB_F-2_doorway_43",
       "type": "door_to_hallway",
       "weight": 50,
-      "accessible": false
+      "accessible": true
     },
     {
       "source": "MB_F-2_doorway_7",

--- a/mobile/data/buildings/VL/1-nav.json
+++ b/mobile/data/buildings/VL/1-nav.json
@@ -1654,7 +1654,7 @@
       "target": "VL_F1_doorway_38",
       "type": "door_to_hallway",
       "weight": 115,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "VL_F1_doorway_37",

--- a/mobile/data/buildings/VL/2-nav.json
+++ b/mobile/data/buildings/VL/2-nav.json
@@ -812,7 +812,7 @@
       "target": "VL_F1_doorway_60",
       "type": "door_to_hallway",
       "weight": 112,
-      "accessible": true
+      "accessible": false
     },
     {
       "source": "VL_F1_doorway_60",


### PR DESCRIPTION
### Summary

This pull request adds accessibility metadata to the indoor floor navigation JSON files for all covered buildings (H, MB, CC, VL).

Each `floor-nav.json` file has been updated to mark pathways and structures as accessible or inaccessible for students with disabilities.

### Changes

**Accessibility tags added to all floor navigation JSON files:**

- Elevator nodes and their connecting edges tagged as `"accessible": true`
- Stair and escalator nodes and their connecting edges tagged as `"accessible": false`
- Edges between adjacent elevator nodes marked as `"accessible": true`
- Edges between adjacent stair nodes marked as `"accessible": false`

### Buildings Updated

| Building | Floors Updated |
|----------|---------------|
| Hall (H) | All floors |
| JMSB (MB) | All floors |
| Central Building (CC) | All floors |
| Vanier Library (VL) | All floors |

### Example
Before:
<img width="527" height="702" alt="image" src="https://github.com/user-attachments/assets/eaffcd1e-e65d-4ddf-ad2f-637417daf616" />

After:
Red marks inaccessible 
<img width="555" height="719" alt="image" src="https://github.com/user-attachments/assets/3f35b82a-f27f-4c64-9d9a-f72da9773b81" />


### Linked Issues

Closes #81
Part of #80 (US-4.3: Show directions for students with disabilities)
Part of #72 (EPIC #4: Indoor Directions)