### PR TITLE
[BUG FIX] VL Building Floor 1 Showing "Floor undefined" With No Rooms

### DIFF
--- a/data/buildings/VL/1-nav.json
+++ b/data/buildings/VL/1-nav.json
@@ -1,6 +1,7 @@
 {
   "meta": {
-    "buildingId": "VL"
+    "buildingId": "VL",
+    "floor": 1
   },
   "nodes": [
     {


### PR DESCRIPTION
fix for small bug #246

# Root Cause 
1.nav.json was missing the floor key in the meta object without this, it returned undefined which produced a floor without any rooms. 

# Fix 
Added the missing ["floor": 1] to the meta block in [1-nav.json]

# Actual behavior
<img width="274" height="610" alt="image" src="https://github.com/user-attachments/assets/812d928a-0c12-4b58-9545-12b69975569a" />

# Notes
It is normal floor 2 has nothing yet, since we haven't assigned any names to the labels