### PR TITLE
[BUG] Fixed Disapearing Navigation UI After Clearing Route

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -861,7 +861,7 @@ export default function Index() {
             setShowIndoorMapModal(false);
             setIndoorPresetRoute(null);
           }}
-          onClearRoute={clearRoute}
+          onClearRoute={handleEndDirections}
          />
 
       {!navigationActive && (


### PR DESCRIPTION
## Fix UI State Desync When Clearing Indoor Routes

### Problem
When users cleared a route from within the IndoorMapModal and closed it, the UI entered a broken state:
- SearchBar and navigation controls disappeared
- Route artifacts (polylines/arrows) remained visible on the map
- App was stuck in a "ghost" navigation state with no way to recover

### Root Cause
The `onClearRoute` callback was calling `clearRoute()`, which only cleared route coordinates but didn't reset the navigation state variable `combinedRouteActive` to `false`. This caused the app to think navigation was still active, so UI components controlled by `!navigationActive` failed to render.

### Solution
Changed `onClearRoute={clearRoute}` to `onClearRoute={handleEndDirections}` in `IndoorMapModal` props.

`handleEndDirections()` now properly:
- Clears route coordinates
- Resets `combinedRouteActive` to `false`
- Clears start/destination choices and preset routes
- Removes all route visuals from the map
- Restores the normal SearchBar UI

### Testing
All tests pass
Tested with multi-leg routes (building + room navigation)

### Visuals:
Once the indoor is cleared and closed, the navigation UI now looks as it is expected to:
<img width="334" height="713" alt="image" src="https://github.com/user-attachments/assets/4c1b187e-b3b7-40da-be4a-fa0287273527" />

Closes #248 