### PR TITLE
[BUG FIX] Show "start directions" if start and building are the same

### DIFF
--- a/components/expandedSearchBar.tsx
+++ b/components/expandedSearchBar.tsx
@@ -601,7 +601,10 @@ export default function ExpandedSearchBar({
             )}
 
             {(() => {
-              const isCurrentLocation = !start || start.id === "current-location";
+              const isCurrentLocation =
+                !start ||
+                start.id === "current-location" ||
+                start.id === currentBuilding?.id;
 
               if (!routeActive && destination && isCurrentLocation && onStartRoute) {
                 return (


### PR DESCRIPTION
## Summary of changes
The "start directions" button is now visible in the expanded search bar when the start point corresponds to the current building, and not only if `start.id === 'current-location'`. For example, if we are inside the Hall building and the search bar's start displays "Hall Building" instead of "My current location", we will now see the "Start directions" button.

## Related Tasks
- #212 

## Visuals
### We are at Hall Building
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-03-30 at 14 54 30" src="https://github.com/user-attachments/assets/e9b03cec-f322-49e8-9eb6-c61d9ea23d45" />

### Start is "Hall Building" and the "Start Directions" button is shown instead of "Preview route"
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-03-30 at 15 19 50" src="https://github.com/user-attachments/assets/1a4604c5-2751-4669-8f04-b58d19a133b1" />

## Steps to Reproduce
1. Set your location to the Hall Building (latitude: 45.4971, longitude: -73.5789).
2. Click on the searh bar
3. Verify that the start location is set to "Henry F. Hall Building (H)"
4. Set the destination to "John Molson School of Business (MB)"
5. Verify that the "Start Directions" button appear, and is clickable.
