### PR TITLE
[BUG FIX] Indoor/outdoor route title

### DIFF
--- a/data/buildings/CC/1-nav.json
+++ b/data/buildings/CC/1-nav.json
@@ -223,7 +223,7 @@
       "y": 904,
       "latitude": 45.45850012191065, 
       "longitude": -73.64074316181494,
-      "label": "",
+      "label": "CC building entry",
       "accessible": true
     },
     {
@@ -233,7 +233,7 @@
       "floor": 1,
       "x": 88,
       "y": 904,
-      "label": "",
+      "label": "CC building exit",
       "accessible": true
     },
     {
@@ -245,7 +245,7 @@
       "y": 985,
       "latitude": 45.45815018667116, 
       "longitude": -73.63990818920387,
-      "label": "",
+      "label": "CC building entry",
       "accessible": true
     },
     {
@@ -255,7 +255,7 @@
       "floor": 1,
       "x": 1948,
       "y": 985,
-      "label": "",
+      "label": "CC building exit",
       "accessible": true
     },
     {
@@ -407,7 +407,7 @@
       "y": 1072,
       "latitude": 45.45844917381449, 
       "longitude": -73.64078404319054,
-      "label": "",
+      "label": "CC building entry",
       "accessible": true
     },
     {
@@ -417,7 +417,7 @@
       "floor": 1,
       "x": 83,
       "y": 1072,
-      "label": "",
+      "label": "CC building exit",
       "accessible": true
     },
     {
@@ -539,7 +539,7 @@
       "y": 1066,
       "latitude": 45.458115149767515, 
       "longitude": -73.63992578340687,
-      "label": "",
+      "label": "CC building entry",
       "accessible": true
     },
     {
@@ -549,7 +549,7 @@
       "floor": 1,
       "x": 1948,
       "y": 1066,
-      "label": "",
+      "label": "CC building exit",
       "accessible": true
     },
     {

--- a/data/buildings/H/1-nav.json
+++ b/data/buildings/H/1-nav.json
@@ -243,7 +243,7 @@
       "y": 1381,
       "latitude": 45.497413242368516, 
       "longitude": -73.57845389601285,
-      "label": "",
+      "label": "H building entry",
       "accessible": true
     },
     {
@@ -253,7 +253,7 @@
       "floor": 1,
       "x": 1908,
       "y": 1381,
-      "label": "",
+      "label": "H building exit",
       "accessible": true
     },
     {
@@ -435,7 +435,7 @@
       "y": 1580,
       "latitude": 45.497007052636114, 
       "longitude": -73.57868314622948,
-      "label": "",
+      "label": "H building entry",
       "accessible": false
     },
     {
@@ -445,7 +445,7 @@
       "floor": 1,
       "x": 655,
       "y": 1580,
-      "label": "",
+      "label": "H building exit",
       "accessible": false
     },
     {
@@ -457,7 +457,7 @@
       "y": 1585,
       "latitude": 45.4970757778617, 
       "longitude": -73.5786111002341,
-      "label": "",
+      "label": "H building entry",
       "accessible": true
     },
     {
@@ -467,7 +467,7 @@
       "floor": 1,
       "x": 831,
       "y": 1585,
-      "label": "",
+      "label": "H building exit",
       "accessible": true
     },
     {

--- a/data/buildings/H/2-nav.json
+++ b/data/buildings/H/2-nav.json
@@ -221,7 +221,7 @@
       "floor": 2,
       "x": 240,
       "y": 895,
-      "label": "",
+      "label": "H building entry",
       "accessible": true
     },
     {
@@ -231,7 +231,7 @@
       "floor": 2,
       "x": 240,
       "y": 895,
-      "label": "",
+      "label": "H building exit",
       "accessible": true
     },
     {
@@ -461,7 +461,7 @@
       "floor": 2,
       "x": 574,
       "y": 400,
-      "label": "",
+      "label": "H building entry",
       "accessible": true
     },
     {
@@ -471,7 +471,7 @@
       "floor": 2,
       "x": 574,
       "y": 400,
-      "label": "",
+      "label": "H building exit",
       "accessible": true
     },
     {

--- a/data/buildings/MB/1-nav.json
+++ b/data/buildings/MB/1-nav.json
@@ -633,7 +633,7 @@
       "y": 1808,
       "latitude": 45.4955008664397, 
       "longitude": -73.57915690500853,
-      "label": "",
+      "label": "MB building entry",
       "accessible": true
     },
     {
@@ -643,7 +643,7 @@
       "floor": 1,
       "x": 692,
       "y": 1808,
-      "label": "",
+      "label": "MB building exit",
       "accessible": true
     },
     {
@@ -895,7 +895,7 @@
       "y": 209,
       "latitude": 45.495217933169, 
       "longitude": -73.57857958459395,
-      "label": "",
+      "label": "MB building entry",
       "accessible": true
     },
     {
@@ -907,7 +907,7 @@
       "y": 209,
       "latitude": 45.495217933169, 
       "longitude": -73.57857958459395,
-      "label": "",
+      "label": "MB building exit",
       "accessible": true
     },
     {

--- a/data/buildings/MB/S2-nav.json
+++ b/data/buildings/MB/S2-nav.json
@@ -1231,7 +1231,7 @@
       "floor": -2,
       "x": 335,
       "y": 889,
-      "label": "",
+      "label": "MB building entry",
       "accessible": true
     },
     {
@@ -1241,7 +1241,7 @@
       "floor": -2,
       "x": 335,
       "y": 889,
-      "label": "",
+      "label": "MB building exit",
       "accessible": true
     }
   ],

--- a/data/buildings/VL/1-nav.json
+++ b/data/buildings/VL/1-nav.json
@@ -163,7 +163,7 @@
       "y": 1913,
       "latitude": 45.459073760236066,
       "longitude": -73.63892445678594,
-      "label": "",
+      "label": "VL building entry",
       "accessible": true
     },
     {
@@ -173,7 +173,7 @@
       "floor": 1,
       "x": 976,
       "y": 1913,
-      "label": "",
+      "label": "VL building exit",
       "accessible": true
     },
     {


### PR DESCRIPTION
# summary
Data fix: populate human-readable labels for all building_entry and building_exit nodes in CC nav data.

# Visual of fix
<img width="308" height="690" alt="image" src="https://github.com/user-attachments/assets/872bae22-2076-4b34-931e-331750d45d20" />
